### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,3 @@ No mirror twin. Lives only in `vyos`.
 
 - This is effectively a placeholder. If image-distribution metadata (manifests, signing keys, release notes) is to live in git, this is the natural home — but coordinate with `vyos-nightly-build` (which already publishes minisign-signed releases) before duplicating.
 - No branch protection on default branch (audit baseline 2026-04-18). Treat any new content as needing fresh repo settings.
-
----
-
-This file is mirrored on Confluence: [`vyos/public-images`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818020540). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+## Project purpose
+
+Public metadata/landing repo for "publicly available rolling and stream release images" of VyOS. Created 2025-02-13. Currently contains only `README.md` — no build scripts, no workflows, no Debian packaging. Acts as a discoverable URL for image-distribution metadata.
+
+## Tech stack
+
+- None. Markdown only.
+
+## Build / test / run
+
+Nothing to build. Edit `README.md` and push.
+
+## Repository layout
+
+- `README.md` — single-line description ("Publicly available rolling and stream release images").
+
+## Cross-repo context
+
+Companion to `vyos/vyos-nightly-build` (the actual ISO-build scheduler that signs and publishes nightly images via GitHub Releases) and `VyOS-Networks/vyos-stream-builds` (the rolling/sagitta/circinus stream pipelines). Image publication itself lives elsewhere — this repo is the user-visible front door.
+
+## Conventions
+
+- Default branch `main` (not `current`).
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev) when the repo gets real content; today no PR-message workflow is configured.
+- Public visibility — keep contents non-sensitive.
+
+## Mirror relationship
+
+No mirror twin. Lives only in `vyos`.
+
+## Notes for future contributors
+
+- This is effectively a placeholder. If image-distribution metadata (manifests, signing keys, release notes) is to live in git, this is the natural home — but coordinate with `vyos-nightly-build` (which already publishes minisign-signed releases) before duplicating.
+- No branch protection on default branch (audit baseline 2026-04-18). Treat any new content as needing fresh repo settings.
+
+---
+
+This file is mirrored on Confluence: [`vyos/public-images`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818020540). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
