### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Project purpose
+
+Public metadata/landing repo for "publicly available rolling and stream release images" of VyOS. Created 2025-02-13. Currently contains only `README.md` — no build scripts, no workflows, no Debian packaging. Acts as a discoverable URL for image-distribution metadata.
+
+## Tech stack
+
+- None. Markdown only.
+
+## Build / test / run
+
+Nothing to build. Edit `README.md` and push.
+
+## Repository layout
+
+- `README.md` — single-line description ("Publicly available rolling and stream release images").
+
+## Cross-repo context
+
+Companion to `vyos/vyos-nightly-build` (the actual ISO-build scheduler that signs and publishes nightly images via GitHub Releases) and `VyOS-Networks/vyos-stream-builds` (the rolling/sagitta/circinus stream pipelines). Image publication itself lives elsewhere — this repo is the user-visible front door.
+
+## Conventions
+
+- Default branch `main` (not `current`).
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev) when the repo gets real content; today no PR-message workflow is configured.
+- Public visibility — keep contents non-sensitive.
+
+## Mirror relationship
+
+No mirror twin. Lives only in `vyos`.
+
+## Notes for future contributors
+
+- This is effectively a placeholder. If image-distribution metadata (manifests, signing keys, release notes) is to live in git, this is the natural home — but coordinate with `vyos-nightly-build` (which already publishes minisign-signed releases) before duplicating.
+- No branch protection on default branch (audit baseline 2026-04-18). Treat any new content as needing fresh repo settings.


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
